### PR TITLE
Fix post-install script when project lives on a path with spaces

### DIFF
--- a/detox/scripts/build_framework.ios.sh
+++ b/detox/scripts/build_framework.ios.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e -x
 
-detoxRootPath="$(dirname $(dirname ${0}))"
+detoxRootPath="$(dirname "$(dirname "$0")")"
 detoxVersion=`node -p "require('${detoxRootPath}/package.json').version"`
 
 sha1=`(echo "${detoxVersion}" && xcodebuild -version) | shasum | awk '{print $1}' #"${2}"`

--- a/detox/scripts/build_universal_framework.sh
+++ b/detox/scripts/build_universal_framework.sh
@@ -9,7 +9,7 @@ function remove_arch() {
     lipo -create "${1}" "${2}" -output "${3}"
 }
 
-UNIVERSAL_OUTPUTFOLDER=${DERIVED_DATA}/Build/Products/${CONFIGURATION}-universal
+UNIVERSAL_OUTPUTFOLDER="${DERIVED_DATA}/Build/Products/${CONFIGURATION}-universal"
 
 # Make sure the output directory exists
 


### PR DESCRIPTION
We found out that a project that lives under a path with spaces make the
post-install script fail. Our CI checks the project under `~/Application Support/project` which makes the script throw an error.

```
> detox@8.2.3 postinstall /Users/bruno/Go
Agent/mobile/node_modules/detox
> node scripts/postinstall.js

+ xcodebuild -version
+++ dirname /Users/bruno/Go
Agent/mobile/node_modules/detox/scripts/build_framework.ios.sh
usage: dirname path
++ dirname
usage: dirname path
+ detoxRootPath=
child_process.js:632
throw err;
^

Error: Command failed: /Users/bruno/Go
Agent/mobile/node_modules/detox/scripts/build_framework.ios.sh
```

This is caused by the argument expansion on shell to think it is taking
more arguments than it should. The strategy is to use quotes on shell
scripts when refering to paths, such as `"$var"`.

This commit wraps the variables refering to paths into quotes to avoid
the argument split when expanding.

Related to:
- https://github.com/wix/Detox/pull/824